### PR TITLE
Set up Laravel Pint + docs (AGENTS.md, README)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -53,6 +53,9 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
 
+      - name: Check code style
+        run: vendor/bin/pint --test
+
       # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
       # Docs: https://getcomposer.org/doc/articles/scripts.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+Guía para agentes de IA que trabajen en este repositorio.
+
+## Qué es este proyecto
+
+`puntodev/paypal` es un **paquete de Laravel** (librería de Composer) que provee un
+cliente liviano para la **PayPal Orders v2 API**, más verificación de IPN clásico.
+No es una aplicación: se publica en Packagist y se consume desde apps Laravel.
+
+- **Namespace:** `Puntodev\Payments\` (PSR-4, mapeado a `src/`)
+- **PHP:** `>=8.4 <9.0`
+- **Dependencia principal:** `illuminate/support` (`^12.53 || ^13.0`)
+- **Licencia:** MIT
+
+## Arquitectura
+
+El paquete se estructura en torno a dos interfaces y sus implementaciones, más un
+builder para construir el payload de la orden.
+
+| Archivo | Rol |
+|---------|-----|
+| `src/PayPal.php` | Interfaz fábrica. Expone `defaultClient()` y `withCredentials($id, $secret)`. |
+| `src/PayPalClient.php` | Implementación de `PayPal`. Conserva credenciales por defecto + flag `useSandbox` y crea instancias de `PayPalApiClient`. |
+| `src/PayPalApi.php` | Interfaz del cliente HTTP: `createOrder`, `findOrderById`, `captureOrder`, `verifyIpn`. |
+| `src/PayPalApiClient.php` | Implementación real contra la API de PayPal usando el HTTP client de Laravel (`Http`). Maneja host sandbox/producción, token OAuth2 cacheado e IPN. |
+| `src/OrderBuilder.php` | Builder fluido que arma el array de la orden v2 (`intent`, `purchase_units`, `payment_source`, etc.). |
+| `src/PayPalServiceProvider.php` | Registra `PayPal` como singleton, publica el config y aplica `mergeConfigFrom`. |
+| `src/PayPalFacade.php` | Facade `Paypal` que resuelve al binding `PayPal::class`. |
+| `config/paypal.php` | Lee `PAYPAL_API_CLIENT_ID`, `PAYPAL_API_CLIENT_SECRET`, `SANDBOX_GATEWAYS`. |
+
+### Detalles importantes de comportamiento
+
+- **Sandbox vs producción:** controlado por el flag `useSandbox`. Cambia el host
+  (`api.sandbox.paypal.com` vs `api.paypal.com`) y la URL de IPN
+  (`ipnpb.sandbox.paypal.com` vs `ipnpb.paypal.com`). El config lo toma de la env
+  `SANDBOX_GATEWAYS`.
+- **Token OAuth2:** `getToken()` cachea el `access_token` por 1000 segundos con clave
+  `paypal-token-{clientId}` vía `Cache::remember`. Usa `withBasicAuth` contra
+  `/v1/oauth2/token` con `grant_type=client_credentials`.
+- **Órdenes:** todas las llamadas a `/v2/checkout/orders` envían el header
+  `Prefer: return=representation` y usan `->throw()`, por lo que los errores HTTP
+  se propagan como `RequestException`.
+- **IPN:** `verifyIpn()` reenvía el querystring con `cmd=_notify-validate` y devuelve
+  el body crudo de PayPal (`VERIFIED` / `INVALID`), sin redirecciones.
+- **OrderBuilder:** intent fijo `CAPTURE`, ítems como `DIGITAL_GOODS`,
+  `shipping_preference: NO_SHIPPING`. El `discount` solo se agrega al `breakdown`
+  cuando es mayor a 0. Locale por defecto `es-AR`.
+
+## Auto-registro en Laravel (package discovery)
+
+Definido en `composer.json` → `extra.laravel`:
+- Provider: `Puntodev\Payments\PayPalServiceProvider`
+- Alias/Facade: `Paypal` → `Puntodev\Payments\PayPalFacade`
+
+## Cómo correr y testear
+
+```bash
+composer install
+composer test            # vendor/bin/phpunit
+composer test-coverage   # genera coverage HTML en ./coverage
+```
+
+- Los tests usan **Orchestra Testbench** (`tests/TestCase.php` extiende
+  `Orchestra\Testbench\TestCase` y registra el service provider).
+- `phpunit.xml.dist` fuerza `SANDBOX_GATEWAYS=true`, así que los tests apuntan al
+  **sandbox de PayPal**.
+- ⚠️ **`tests/PayPalApiTest.php` hace llamadas HTTP reales al sandbox.** Requiere
+  credenciales válidas en `PAYPAL_API_CLIENT_ID` / `PAYPAL_API_CLIENT_SECRET`
+  (en `.env` localmente, o GitHub Secrets en CI). No son tests unitarios aislados.
+- CI: `.github/workflows/php.yml` corre sobre PHP 8.4 en cada push/PR a `master`.
+
+## Convenciones
+
+- Sin framework de estilo configurado; seguir el estilo existente (PSR-12, 4 espacios,
+  `.editorconfig`).
+- Las interfaces (`PayPal`, `PayPalApi`) son el contrato público: si se agrega un método
+  al cliente, agregarlo también a la interfaz y a los tests.
+- Los métodos de la API devuelven `array`/`?array` (el `->json()` de Laravel) o `string`
+  para IPN; mantener esa convención.
+
+## Reglas de workflow (heredadas de la config global del usuario)
+
+- **No commitear en `master`.** Trabajar siempre en branch o worktree.
+- Los PRs se abren siempre como **Draft**.
+- Hacer `git pull` antes de empezar para tener la última versión.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,86 +1,88 @@
 # AGENTS.md
 
-Guía para agentes de IA que trabajen en este repositorio.
+Guidance for AI agents working in this repository.
 
-## Qué es este proyecto
+## What this project is
 
-`puntodev/paypal` es un **paquete de Laravel** (librería de Composer) que provee un
-cliente liviano para la **PayPal Orders v2 API**, más verificación de IPN clásico.
-No es una aplicación: se publica en Packagist y se consume desde apps Laravel.
+`puntodev/paypal` is a **Laravel package** (Composer library) that provides a
+lightweight client for the **PayPal Orders v2 API**, plus classic IPN verification.
+It is not an application: it is published to Packagist and consumed from Laravel apps.
 
-- **Namespace:** `Puntodev\Payments\` (PSR-4, mapeado a `src/`)
+- **Namespace:** `Puntodev\Payments\` (PSR-4, mapped to `src/`)
 - **PHP:** `>=8.4 <9.0`
-- **Dependencia principal:** `illuminate/support` (`^12.53 || ^13.0`)
-- **Licencia:** MIT
+- **Main dependency:** `illuminate/support` (`^12.53 || ^13.0`)
+- **License:** MIT
 
-## Arquitectura
+## Architecture
 
-El paquete se estructura en torno a dos interfaces y sus implementaciones, más un
-builder para construir el payload de la orden.
+The package is built around two interfaces and their implementations, plus a builder
+that assembles the order payload.
 
-| Archivo | Rol |
-|---------|-----|
-| `src/PayPal.php` | Interfaz fábrica. Expone `defaultClient()` y `withCredentials($id, $secret)`. |
-| `src/PayPalClient.php` | Implementación de `PayPal`. Conserva credenciales por defecto + flag `useSandbox` y crea instancias de `PayPalApiClient`. |
-| `src/PayPalApi.php` | Interfaz del cliente HTTP: `createOrder`, `findOrderById`, `captureOrder`, `verifyIpn`. |
-| `src/PayPalApiClient.php` | Implementación real contra la API de PayPal usando el HTTP client de Laravel (`Http`). Maneja host sandbox/producción, token OAuth2 cacheado e IPN. |
-| `src/OrderBuilder.php` | Builder fluido que arma el array de la orden v2 (`intent`, `purchase_units`, `payment_source`, etc.). |
-| `src/PayPalServiceProvider.php` | Registra `PayPal` como singleton, publica el config y aplica `mergeConfigFrom`. |
-| `src/PayPalFacade.php` | Facade `Paypal` que resuelve al binding `PayPal::class`. |
-| `config/paypal.php` | Lee `PAYPAL_API_CLIENT_ID`, `PAYPAL_API_CLIENT_SECRET`, `SANDBOX_GATEWAYS`. |
+| File | Role |
+|------|------|
+| `src/PayPal.php` | Factory interface. Exposes `defaultClient()` and `withCredentials($id, $secret)`. |
+| `src/PayPalClient.php` | `PayPal` implementation. Holds the default credentials + `useSandbox` flag and creates `PayPalApiClient` instances. |
+| `src/PayPalApi.php` | HTTP client interface: `createOrder`, `findOrderById`, `captureOrder`, `verifyIpn`. |
+| `src/PayPalApiClient.php` | Real implementation against the PayPal API using Laravel's HTTP client (`Http`). Handles the sandbox/production host, cached OAuth2 token and IPN. |
+| `src/OrderBuilder.php` | Fluent builder that assembles the Orders v2 array (`intent`, `purchase_units`, `payment_source`, etc.). |
+| `src/PayPalServiceProvider.php` | Registers `PayPal` as a singleton, publishes the config and applies `mergeConfigFrom`. |
+| `src/PayPalFacade.php` | `Paypal` facade resolving to the `PayPal::class` binding. |
+| `config/paypal.php` | Reads `PAYPAL_API_CLIENT_ID`, `PAYPAL_API_CLIENT_SECRET`, `SANDBOX_GATEWAYS`. |
 
-### Detalles importantes de comportamiento
+### Important behavior details
 
-- **Sandbox vs producción:** controlado por el flag `useSandbox`. Cambia el host
-  (`api.sandbox.paypal.com` vs `api.paypal.com`) y la URL de IPN
-  (`ipnpb.sandbox.paypal.com` vs `ipnpb.paypal.com`). El config lo toma de la env
-  `SANDBOX_GATEWAYS`.
-- **Token OAuth2:** `getToken()` cachea el `access_token` por 1000 segundos con clave
-  `paypal-token-{clientId}` vía `Cache::remember`. Usa `withBasicAuth` contra
-  `/v1/oauth2/token` con `grant_type=client_credentials`.
-- **Órdenes:** todas las llamadas a `/v2/checkout/orders` envían el header
-  `Prefer: return=representation` y usan `->throw()`, por lo que los errores HTTP
-  se propagan como `RequestException`.
-- **IPN:** `verifyIpn()` reenvía el querystring con `cmd=_notify-validate` y devuelve
-  el body crudo de PayPal (`VERIFIED` / `INVALID`), sin redirecciones.
-- **OrderBuilder:** intent fijo `CAPTURE`, ítems como `DIGITAL_GOODS`,
-  `shipping_preference: NO_SHIPPING`. El `discount` solo se agrega al `breakdown`
-  cuando es mayor a 0. Locale por defecto `es-AR`.
+- **Sandbox vs production:** controlled by the `useSandbox` flag. It switches the host
+  (`api.sandbox.paypal.com` vs `api.paypal.com`) and the IPN URL
+  (`ipnpb.sandbox.paypal.com` vs `ipnpb.paypal.com`). The config reads it from the
+  `SANDBOX_GATEWAYS` env var.
+- **OAuth2 token:** `getToken()` caches the `access_token` for 1000 seconds under the
+  key `paypal-token-{clientId}` via `Cache::remember`. It uses `withBasicAuth` against
+  `/v1/oauth2/token` with `grant_type=client_credentials`.
+- **Orders:** all calls to `/v2/checkout/orders` send the `Prefer: return=representation`
+  header and use `->throw()`, so HTTP errors propagate as `RequestException`.
+- **IPN:** `verifyIpn()` re-posts the query string with `cmd=_notify-validate` and returns
+  PayPal's raw body (`VERIFIED` / `INVALID`), without following redirects.
+- **OrderBuilder:** fixed `CAPTURE` intent, items sent as `DIGITAL_GOODS`,
+  `shipping_preference: NO_SHIPPING`. The `discount` is only added to the `breakdown`
+  when greater than 0. Default locale is `es-AR`.
 
-## Auto-registro en Laravel (package discovery)
+## Laravel auto-registration (package discovery)
 
-Definido en `composer.json` → `extra.laravel`:
+Defined in `composer.json` → `extra.laravel`:
 - Provider: `Puntodev\Payments\PayPalServiceProvider`
 - Alias/Facade: `Paypal` → `Puntodev\Payments\PayPalFacade`
 
-## Cómo correr y testear
+## How to run and test
 
 ```bash
 composer install
 composer test            # vendor/bin/phpunit
-composer test-coverage   # genera coverage HTML en ./coverage
+composer test-coverage   # generates HTML coverage report under ./coverage
+composer lint            # vendor/bin/pint --test (style check, no changes)
+composer format          # vendor/bin/pint (fix style)
 ```
 
-- Los tests usan **Orchestra Testbench** (`tests/TestCase.php` extiende
-  `Orchestra\Testbench\TestCase` y registra el service provider).
-- `phpunit.xml.dist` fuerza `SANDBOX_GATEWAYS=true`, así que los tests apuntan al
-  **sandbox de PayPal**.
-- ⚠️ **`tests/PayPalApiTest.php` hace llamadas HTTP reales al sandbox.** Requiere
-  credenciales válidas en `PAYPAL_API_CLIENT_ID` / `PAYPAL_API_CLIENT_SECRET`
-  (en `.env` localmente, o GitHub Secrets en CI). No son tests unitarios aislados.
-- CI: `.github/workflows/php.yml` corre sobre PHP 8.4 en cada push/PR a `master`.
+- Tests use **Orchestra Testbench** (`tests/TestCase.php` extends
+  `Orchestra\Testbench\TestCase` and registers the service provider).
+- `phpunit.xml.dist` forces `SANDBOX_GATEWAYS=true`, so tests target the
+  **PayPal sandbox**.
+- ⚠️ **`tests/PayPalApiTest.php` makes real HTTP calls to the sandbox.** It requires
+  valid credentials in `PAYPAL_API_CLIENT_ID` / `PAYPAL_API_CLIENT_SECRET`
+  (in `.env` locally, or GitHub Secrets in CI). These are not isolated unit tests.
+- CI: `.github/workflows/php.yml` runs on PHP 8.4 on every push/PR to `master`,
+  including a Pint code-style check.
 
-## Convenciones
+## Conventions
 
-- Sin framework de estilo configurado; seguir el estilo existente (PSR-12, 4 espacios,
-  `.editorconfig`).
-- Las interfaces (`PayPal`, `PayPalApi`) son el contrato público: si se agrega un método
-  al cliente, agregarlo también a la interfaz y a los tests.
-- Los métodos de la API devuelven `array`/`?array` (el `->json()` de Laravel) o `string`
-  para IPN; mantener esa convención.
+- Code style is enforced by **Laravel Pint** (`pint.json`, `laravel` preset). Run
+  `composer format` before committing; `composer lint` is what CI runs.
+- The interfaces (`PayPal`, `PayPalApi`) are the public contract: when adding a method
+  to the client, add it to the interface and to the tests as well.
+- API methods return `array`/`?array` (Laravel's `->json()`) or `string` for IPN; keep
+  that convention.
 
-## Reglas de workflow (heredadas de la config global del usuario)
+## Workflow rules (inherited from the user's global config)
 
-- **No commitear en `master`.** Trabajar siempre en branch o worktree.
-- Los PRs se abren siempre como **Draft**.
-- Hacer `git pull` antes de empezar para tener la última versión.
+- **Do not commit on `master`.** Always work on a branch or worktree.
+- PRs are always opened as **Draft**.
+- Run `git pull` before starting to make sure you have the latest version.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,150 @@
-# Very short description of the package
+# PayPal API Client for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/puntodev/paypal.svg?style=flat-square)](https://packagist.org/packages/puntodev/paypal)
-[![Build Status](https://img.shields.io/travis/puntodev/paypal/master.svg?style=flat-square)](https://travis-ci.org/puntodev/paypal)
-[![Quality Score](https://img.shields.io/scrutinizer/g/puntodev/paypal.svg?style=flat-square)](https://scrutinizer-ci.com/g/puntodev/paypal)
 [![Total Downloads](https://img.shields.io/packagist/dt/puntodev/paypal.svg?style=flat-square)](https://packagist.org/packages/puntodev/paypal)
 
-This is where your description should go. Try and limit it to a paragraph or two, and maybe throw in a mention of what PSRs you support to avoid any confusion with users and contributors.
+A lightweight Laravel package that wraps the [PayPal Orders v2 API](https://developer.paypal.com/docs/api/orders/v2/)
+(create, find and capture orders) and provides classic IPN verification. It uses
+Laravel's HTTP client under the hood and caches the OAuth2 access token automatically.
+
+## Requirements
+
+- PHP `>=8.4 <9.0`
+- Laravel 12 / 13 (`illuminate/support` `^12.53 || ^13.0`)
 
 ## Installation
 
-You can install the package via composer:
+Install via composer:
 
 ```bash
 composer require puntodev/paypal
 ```
 
+The package auto-registers its service provider and the `Paypal` facade via Laravel
+package discovery. To publish the config file:
+
+```bash
+php artisan vendor:publish --provider="Puntodev\Payments\PayPalServiceProvider" --tag="config"
+```
+
+## Configuration
+
+Set the following environment variables:
+
+```dotenv
+PAYPAL_API_CLIENT_ID=your-client-id
+PAYPAL_API_CLIENT_SECRET=your-client-secret
+SANDBOX_GATEWAYS=true   # true -> sandbox, false -> production
+```
+
+These map to `config/paypal.php`:
+
+```php
+return [
+    'client_id' => env('PAYPAL_API_CLIENT_ID'),
+    'client_secret' => env('PAYPAL_API_CLIENT_SECRET'),
+    'use_sandbox' => env('SANDBOX_GATEWAYS', false),
+];
+```
+
+When `use_sandbox` is `true` the client targets `api.sandbox.paypal.com` and the
+sandbox IPN endpoint; otherwise it targets production.
+
 ## Usage
 
-``` php
-// Usage description here
+### Resolving the client
+
+Inject the `PayPal` contract (or use the `Paypal` facade) and obtain a `PayPalApi`
+instance. Use `defaultClient()` to use the configured credentials, or
+`withCredentials()` to override them at runtime (e.g. for multi-tenant setups):
+
+```php
+use Puntodev\Payments\PayPal;
+
+public function __construct(private PayPal $paypal) {}
+
+// With the credentials from config/paypal.php
+$api = $this->paypal->defaultClient();
+
+// Or with per-request credentials (sandbox flag still comes from config)
+$api = $this->paypal->withCredentials($clientId, $clientSecret);
 ```
 
-### Testing
+### Building an order
 
-``` bash
-composer test
+`OrderBuilder` produces the payload for the Orders v2 API. The order intent is
+`CAPTURE`, items are sent as `DIGITAL_GOODS` with `NO_SHIPPING`, and a discount is
+only included when greater than zero:
+
+```php
+use Puntodev\Payments\OrderBuilder;
+
+$order = (new OrderBuilder())
+    ->externalId('your-internal-id')
+    ->currency('USD')
+    ->amount(23.20)
+    ->discount(2.20)            // optional
+    ->description('My custom product')
+    ->brandName('My brand name')
+    ->locale('es-AR')           // defaults to es-AR
+    ->returnUrl('https://example.com/return')
+    ->cancelUrl('https://example.com/cancel')
+    ->make();
 ```
 
-### Changelog
+### Creating, finding and capturing orders
 
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+```php
+$created = $api->createOrder($order);
+$orderId = $created['id'];
+
+// Send the buyer to the "payer-action" link to approve the payment
+$approveUrl = collect($created['links'])
+    ->firstWhere('rel', 'payer-action')['href'];
+
+// Later, fetch or capture the order
+$order = $api->findOrderById($orderId);
+$capture = $api->captureOrder($orderId);
+```
+
+All order methods return the decoded JSON response as an `array` and throw
+`Illuminate\Http\Client\RequestException` on HTTP errors.
+
+### Verifying IPN notifications
+
+```php
+// In your IPN webhook controller
+$status = $api->verifyIpn($request->getContent()); // "VERIFIED" or "INVALID"
+
+if ($status === 'VERIFIED') {
+    // process the notification
+}
+```
+
+## Testing
+
+```bash
+composer test            # runs PHPUnit
+composer test-coverage   # generates HTML coverage report
+```
+
+> **Note:** the test suite (`tests/PayPalApiTest.php`) makes **real HTTP calls to
+> the PayPal sandbox**. You must provide valid sandbox credentials via
+> `PAYPAL_API_CLIENT_ID` and `PAYPAL_API_CLIENT_SECRET`. `phpunit.xml.dist` forces
+> `SANDBOX_GATEWAYS=true`.
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### Security
+## Security
 
-If you discover any security related issues, please email mariano.goldman@puntodev.com.ar instead of using the issue tracker.
+If you discover any security related issues, please email mariano.goldman@puntodev.com.ar
+instead of using the issue tracker.
 
 ## Credits
 
@@ -47,7 +154,3 @@ If you discover any security related issues, please email mariano.goldman@puntod
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-
-## Laravel Package Boilerplate
-
-This package was generated using the [Laravel Package Boilerplate](https://laravelpackageboilerplate.com).

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "illuminate/support": "^12.53 || ^13.0"
     },
     "require-dev": {
+        "laravel/pint": "^1.29",
         "orchestra/testbench": "^10.9",
         "phpunit/phpunit": "^12.4"
     },
@@ -35,7 +36,9 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "lint": "vendor/bin/pint --test",
+        "format": "vendor/bin/pint"
     },
     "config": {
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "350bea2c364e10c7070f1893f397f8b0",
+    "content-hash": "3e5045414eb7dc0841a8272e16db887f",
     "packages": [
         {
             "name": "brick/math",
@@ -6140,6 +6140,74 @@
                 "source": "https://github.com/laravel/pail"
             },
             "time": "2026-02-09T13:44:54+00:00"
+        },
+        {
+            "name": "laravel/pint",
+            "version": "v1.29.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pint.git",
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-tokenizer": "*",
+                "ext-xml": "*",
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "illuminate/view": "^12.56.0",
+                "larastan/larastan": "^3.9.6",
+                "laravel-zero/framework": "^12.1.0",
+                "mockery/mockery": "^1.6.12",
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.3"
+            },
+            "bin": [
+                "builds/pint"
+            ],
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "App\\": "app/",
+                    "Database\\Seeders\\": "database/seeders/",
+                    "Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "An opinionated code formatter for PHP.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "dev",
+                "format",
+                "formatter",
+                "lint",
+                "linter",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pint/issues",
+                "source": "https://github.com/laravel/pint"
+            },
+            "time": "2026-04-20T15:26:14+00:00"
         },
         {
             "name": "laravel/tinker",

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,10 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "declare_strict_types": false,
+        "ordered_imports": {
+            "sort_algorithm": "alpha"
+        },
+        "no_unused_imports": true
+    }
+}

--- a/pint.json
+++ b/pint.json
@@ -5,6 +5,9 @@
         "ordered_imports": {
             "sort_algorithm": "alpha"
         },
-        "no_unused_imports": true
+        "no_unused_imports": true,
+        "concat_space": {
+            "spacing": "one"
+        }
     }
 }

--- a/src/OrderBuilder.php
+++ b/src/OrderBuilder.php
@@ -1,107 +1,92 @@
 <?php
 
-
 namespace Puntodev\Payments;
-
 
 class OrderBuilder
 {
     private string $externalId = '';
+
     private string $currency = '';
+
     private float $amount = 0;
+
     private float $discount = 0;
+
     private string $description = '';
+
     private string $brandName = '';
+
     private string $locale = 'es-AR';
+
     private string $returnUrl = '';
+
     private string $cancelUrl = '';
 
     /**
      * OrderBuilder constructor.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
-    /**
-     * @param string $externalId
-     * @return OrderBuilder
-     */
     public function externalId(string $externalId): OrderBuilder
     {
         $this->externalId = $externalId;
+
         return $this;
     }
 
     public function currency(string $currency): OrderBuilder
     {
         $this->currency = $currency;
+
         return $this;
     }
 
-    /**
-     * @param float $amount
-     * @return OrderBuilder
-     */
     public function amount(float $amount): OrderBuilder
     {
         $this->amount = $amount;
+
         return $this;
     }
 
     public function discount(float $discount): OrderBuilder
     {
         $this->discount = $discount;
+
         return $this;
     }
 
-    /**
-     * @param string $description
-     * @return OrderBuilder
-     */
     public function description(string $description): OrderBuilder
     {
         $this->description = $description;
+
         return $this;
     }
 
-    /**
-     * @param string $brandName
-     * @return OrderBuilder
-     */
     public function brandName(string $brandName): OrderBuilder
     {
         $this->brandName = $brandName;
+
         return $this;
     }
 
-    /**
-     * @param string $locale
-     * @return OrderBuilder
-     */
     public function locale(string $locale): OrderBuilder
     {
         $this->locale = $locale;
+
         return $this;
     }
 
-    /**
-     * @param string $returnUrl
-     * @return OrderBuilder
-     */
     public function returnUrl(string $returnUrl): OrderBuilder
     {
         $this->returnUrl = $returnUrl;
+
         return $this;
     }
 
-    /**
-     * @param string $cancelUrl
-     * @return OrderBuilder
-     */
     public function cancelUrl(string $cancelUrl): OrderBuilder
     {
         $this->cancelUrl = $cancelUrl;
+
         return $this;
     }
 
@@ -132,13 +117,13 @@ class OrderBuilder
                                 'currency_code' => $this->currency,
                                 'value' => round($this->amount, 2),
                             ],
-                            'category' => 'DIGITAL_GOODS'
-                        ]
+                            'category' => 'DIGITAL_GOODS',
+                        ],
                     ],
                     'payment_options' => [
-                        'allowed_payment_method' => 'INSTANT_FUNDING_SOURCE'
+                        'allowed_payment_method' => 'INSTANT_FUNDING_SOURCE',
                     ],
-                ]
+                ],
             ],
             'payment_source' => [
                 'paypal' => [
@@ -149,9 +134,9 @@ class OrderBuilder
                         'payment_method_preference' => 'IMMEDIATE_PAYMENT_REQUIRED',
                         'locale' => $this->locale,
                         'return_url' => $this->returnUrl,
-                        'cancel_url' => $this->cancelUrl
-                    ]
-                ]
+                        'cancel_url' => $this->cancelUrl,
+                    ],
+                ],
             ],
         ];
 
@@ -161,6 +146,7 @@ class OrderBuilder
                 'value' => round($this->discount, 2),
             ];
         }
+
         return $arr;
     }
 }

--- a/src/PayPalApi.php
+++ b/src/PayPalApi.php
@@ -7,29 +7,21 @@ use Illuminate\Http\Client\RequestException;
 interface PayPalApi
 {
     /**
-     * @param array $order
-     * @return array
      * @throws RequestException
      */
     public function createOrder(array $order): array;
 
     /**
-     * @param string $id
-     * @return array|null
      * @throws RequestException
      */
     public function findOrderById(string $id): ?array;
 
     /**
-     * @param string $orderId
-     * @return array|null
      * @throws RequestException
      */
     public function captureOrder(string $orderId): ?array;
 
     /**
-     * @param string $querystring
-     * @return string
      * @throws RequestException
      */
     public function verifyIpn(string $querystring): string;

--- a/src/PayPalApiClient.php
+++ b/src/PayPalApiClient.php
@@ -10,8 +10,11 @@ use Illuminate\Support\Facades\Log;
 class PayPalApiClient implements PayPalApi
 {
     private string $apiClientKey;
+
     private string $apiClientSecret;
+
     private string $host;
+
     private string $ipnUrl;
 
     public function __construct(string $apiClientKey, string $apiClientSecret, bool $useSandbox)
@@ -32,6 +35,7 @@ class PayPalApiClient implements PayPalApi
     public function createOrder(array $order): array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->withHeaders([
                 'Prefer' => 'return=representation',
@@ -47,6 +51,7 @@ class PayPalApiClient implements PayPalApi
     public function findOrderById(string $id): ?array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->get("https://{$this->host}/v2/checkout/orders/$id")
             ->throw()
@@ -59,6 +64,7 @@ class PayPalApiClient implements PayPalApi
     public function captureOrder(string $orderId): ?array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->withHeaders([
                 'Prefer' => 'return=representation',
@@ -79,7 +85,7 @@ class PayPalApiClient implements PayPalApi
             'Connection' => 'Close',
         ])
             ->withoutRedirecting()
-            ->withBody('cmd=_notify-validate&' . $querystring, 'application/x-www-form-urlencoded')
+            ->withBody('cmd=_notify-validate&'.$querystring, 'application/x-www-form-urlencoded')
             ->post($this->ipnUrl)
             ->throw()
             ->body();
@@ -89,6 +95,7 @@ class PayPalApiClient implements PayPalApi
     {
         return Cache::remember("paypal-token-{$this->apiClientKey}", 1000, function () {
             Log::debug('Obtaining PayPal token from live server');
+
             return Http::withBasicAuth($this->apiClientKey, $this->apiClientSecret)
                 ->asForm()
                 ->post("https://{$this->host}/v1/oauth2/token", [

--- a/src/PayPalApiClient.php
+++ b/src/PayPalApiClient.php
@@ -85,7 +85,7 @@ class PayPalApiClient implements PayPalApi
             'Connection' => 'Close',
         ])
             ->withoutRedirecting()
-            ->withBody('cmd=_notify-validate&'.$querystring, 'application/x-www-form-urlencoded')
+            ->withBody('cmd=_notify-validate&' . $querystring, 'application/x-www-form-urlencoded')
             ->post($this->ipnUrl)
             ->throw()
             ->body();

--- a/src/PayPalClient.php
+++ b/src/PayPalClient.php
@@ -5,7 +5,9 @@ namespace Puntodev\Payments;
 class PayPalClient implements PayPal
 {
     private string $clientId;
+
     private string $clientSecret;
+
     private bool $useSandbox;
 
     public function __construct(string $clientId, string $clientSecret, bool $useSandbox)

--- a/src/PayPalServiceProvider.php
+++ b/src/PayPalServiceProvider.php
@@ -10,14 +10,14 @@ class PayPalServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/paypal.php' => config_path('paypal.php'),
+                __DIR__ . '/../config/paypal.php' => config_path('paypal.php'),
             ], 'config');
         }
     }
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/paypal.php', 'paypal');
+        $this->mergeConfigFrom(__DIR__ . '/../config/paypal.php', 'paypal');
 
         $this->app->singleton(PayPal::class, function ($app) {
             return new PayPalClient(

--- a/src/PayPalServiceProvider.php
+++ b/src/PayPalServiceProvider.php
@@ -10,14 +10,14 @@ class PayPalServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../config/paypal.php' => config_path('paypal.php'),
+                __DIR__.'/../config/paypal.php' => config_path('paypal.php'),
             ], 'config');
         }
     }
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/paypal.php', 'paypal');
+        $this->mergeConfigFrom(__DIR__.'/../config/paypal.php', 'paypal');
 
         $this->app->singleton(PayPal::class, function ($app) {
             return new PayPalClient(

--- a/tests/OrderBuilderTest.php
+++ b/tests/OrderBuilderTest.php
@@ -11,7 +11,7 @@ class OrderBuilderTest extends TestCase
     #[Test]
     public function create_order_with_int_amount()
     {
-        $order = (new OrderBuilder())
+        $order = (new OrderBuilder)
             ->externalId('31fe5538-8589-437d-8823-3b0574186a5f')
             ->currency('USD')
             ->amount(23.206)
@@ -34,11 +34,11 @@ class OrderBuilderTest extends TestCase
                                 'currency_code' => 'USD',
                                 'value' => 23.21,
                             ],
-                        ]
+                        ],
                     ],
                     'description' => 'My custom product',
                     'payment_options' => [
-                        'allowed_payment_method' => 'INSTANT_FUNDING_SOURCE'
+                        'allowed_payment_method' => 'INSTANT_FUNDING_SOURCE',
                     ],
                     'items' => [
                         [
@@ -50,9 +50,9 @@ class OrderBuilderTest extends TestCase
                                 'value' => 23.21,
                             ],
                             'category' => 'DIGITAL_GOODS',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             'payment_source' => [
                 'paypal' => [
@@ -63,7 +63,7 @@ class OrderBuilderTest extends TestCase
                         'payment_method_preference' => 'IMMEDIATE_PAYMENT_REQUIRED',
                         'shipping_preference' => 'NO_SHIPPING',
                         'return_url' => 'http://localhost:8080/return',
-                        'cancel_url' => 'http://localhost:8080/cancel'
+                        'cancel_url' => 'http://localhost:8080/cancel',
                     ],
                 ],
             ],
@@ -73,7 +73,7 @@ class OrderBuilderTest extends TestCase
     #[Test]
     public function create_order_with_discount()
     {
-        $order = (new OrderBuilder())
+        $order = (new OrderBuilder)
             ->externalId('31fe5538-8589-437d-8823-3b0574186a5f')
             ->currency('USD')
             ->amount(23.99)
@@ -101,11 +101,11 @@ class OrderBuilderTest extends TestCase
                                 'currency_code' => 'USD',
                                 'value' => 3.98,
                             ],
-                        ]
+                        ],
                     ],
                     'description' => 'My custom product',
                     'payment_options' => [
-                        'allowed_payment_method' => 'INSTANT_FUNDING_SOURCE'
+                        'allowed_payment_method' => 'INSTANT_FUNDING_SOURCE',
                     ],
                     'items' => [
                         [
@@ -117,9 +117,9 @@ class OrderBuilderTest extends TestCase
                                 'value' => 23.99,
                             ],
                             'category' => 'DIGITAL_GOODS',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             'payment_source' => [
                 'paypal' => [
@@ -130,7 +130,7 @@ class OrderBuilderTest extends TestCase
                         'payment_method_preference' => 'IMMEDIATE_PAYMENT_REQUIRED',
                         'shipping_preference' => 'NO_SHIPPING',
                         'return_url' => 'http://localhost:8080/return',
-                        'cancel_url' => 'http://localhost:8080/cancel'
+                        'cancel_url' => 'http://localhost:8080/cancel',
                     ],
                 ],
             ],

--- a/tests/PayPalApiTest.php
+++ b/tests/PayPalApiTest.php
@@ -17,7 +17,7 @@ class PayPalApiTest extends TestCase
 
     private PayPalApi $paypalApi;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->paypalApi = new PayPalApiClient(
@@ -34,13 +34,12 @@ class PayPalApiTest extends TestCase
     }
 
     /**
-     * @return string
      * @throws RequestException
      */
     #[Test]
     public function create_order(): string
     {
-        $order = (new OrderBuilder())
+        $order = (new OrderBuilder)
             ->externalId($this->faker->uuid)
             ->currency('USD')
             ->amount(23.20)
@@ -56,7 +55,7 @@ class PayPalApiTest extends TestCase
         $this->assertEquals('PAYER_ACTION_REQUIRED', $createdOrder['status']);
         $this->assertCount(2, $createdOrder['links']);
         $link = collect($createdOrder['links'])
-            ->filter(fn($link) => $link['method'] === 'GET' && $link['rel'] === 'payer-action')
+            ->filter(fn ($link) => $link['method'] === 'GET' && $link['rel'] === 'payer-action')
             ->first();
         $this->assertStringStartsWith('https://www.sandbox.paypal.com/checkoutnow', $link['href']);
 
@@ -65,6 +64,7 @@ class PayPalApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
     #[Test]
@@ -76,6 +76,7 @@ class PayPalApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
     #[Test]
@@ -88,6 +89,7 @@ class PayPalApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
     #[Test]

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app): array
     {
         return [
-            PayPalServiceProvider::class
+            PayPalServiceProvider::class,
         ];
     }
 }


### PR DESCRIPTION
## Summary

Sets up code-style tooling and refreshes project documentation.

### Code style — Laravel Pint
- Add `laravel/pint` as a dev dependency.
- Add `pint.json` (laravel preset, alpha-ordered imports, no unused imports; `declare_strict_types` left off to avoid a mass migration).
- Add `composer lint` (`pint --test`) and `composer format` (`pint`) scripts.
- Add a *Check code style* step to the CI workflow (after dependency install).
- Apply Pint to existing `src/` and `tests/` — **cosmetic only**, no functional changes.

### Docs
- Add `AGENTS.md` documenting architecture, behavior (sandbox switch, token caching, IPN, OrderBuilder) and workflow.
- Rewrite `README.md` (was Laravel boilerplate) with real installation, configuration and usage examples; remove dead Travis/Scrutinizer badges.

## How to use
```bash
composer format   # fix style
composer lint     # check only (what CI runs)
```

## Test plan
- [x] `vendor/bin/pint --test` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)