### PR TITLE
docs: reflect Laravel 13+ requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ It is not an application: it is published to Packagist and consumed from Laravel
 
 - **Namespace:** `Puntodev\Payments\` (PSR-4, mapped to `src/`)
 - **PHP:** `>=8.4 <9.0`
-- **Main dependency:** `illuminate/support` (`^12.53 || ^13.0`)
+- **Main dependency:** `illuminate/support` (`^13.0`, Laravel 13+)
 - **License:** MIT
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Laravel's HTTP client under the hood and caches the OAuth2 access token automati
 ## Requirements
 
 - PHP `>=8.4 <9.0`
-- Laravel 12 / 13 (`illuminate/support` `^12.53 || ^13.0`)
+- Laravel 13+ (`illuminate/support` `^13.0`)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Updates documentation to state the **Laravel 13+** requirement, matching the dependency bump in #48.

- `README.md`: "Laravel 13+ (`illuminate/support` `^13.0`)"
- `AGENTS.md`: main dependency updated to `^13.0` (Laravel 13+)

> Docs-only change, split from the dependency PR (#48). Merge after #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)