### PR TITLE
Automate the release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+# Configures GitHub's "Generate release notes" button.
+# Pull requests are grouped by their labels; the catch-all category ensures
+# every merged PR shows up even when it is unlabeled.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: 🛡️ Security
+      labels:
+        - security
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🧰 Maintenance & Dependencies
+      labels:
+        - chore
+        - dependencies
+        - maintenance
+    - title: 📚 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: master
-          # master is not a protected branch, so the default GITHUB_TOKEN is
-          # enough to push the changelog commit. If master ever gets branch
-          # protection, swap this for an admin PAT stored as a secret
-          # (e.g. token: ${{ secrets.RELEASE_TOKEN }}) and disable enforce_admins.
+          # Admin PAT so the changelog commit can be pushed to the protected
+          # master branch (the default GITHUB_TOKEN is rejected by branch
+          # protection). Requires enforce_admins to be disabled on master.
+          token: ${{ secrets.RELEASE_TOKEN }}
           persist-credentials: true
 
       - name: Update CHANGELOG

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,38 @@
+name: Update Changelog
+
+# When a (non-prerelease) GitHub Release is published, write its notes into
+# CHANGELOG.md under the released version and commit the result back to master.
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v5
+        with:
+          ref: master
+          # master is not a protected branch, so the default GITHUB_TOKEN is
+          # enough to push the changelog commit. If master ever gets branch
+          # protection, swap this for an admin PAT stored as a secret
+          # (e.g. token: ${{ secrets.RELEASE_TOKEN }}) and disable enforce_admins.
+          persist-credentials: true
+
+      - name: Update CHANGELOG
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          branch: master
+          commit_message: "docs: update CHANGELOG for ${{ github.event.release.tag_name }}"
+          file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,114 @@
 # Changelog
 
-All notable changes to `paypal` will be documented in this file
+All notable changes to `paypal` are documented in this file.
 
-## 1.0.0 - 201X-XX-XX
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- initial release
+Released entries below are maintained automatically from the GitHub release notes
+(see `.github/workflows/update-changelog.yml`); the `Unreleased` section tracks the
+range of changes on `master` that have not been released yet.
+
+## [Unreleased]
+
+## v5 - 2026-03-28
+
+- Refactor to use an interface and simplify the `PayPalApi` implementation (#38).
+
+## v4.1.3 - 2026-03-28
+
+- Update dependencies (#37).
+
+## v4.1.2 - 2026-03-07
+
+- Update dependencies (#35).
+
+## v4.1.1 - 2025-11-22
+
+- Update dependencies (#30).
+
+## v4.1.0 - 2025-11-09
+
+- Support for PHP 8.3 and newer (#28).
+
+## v4.0.1 - 2025-05-20
+
+- Update dependencies (#27).
+
+## v4.0.0 - 2025-05-02
+
+- Support Laravel 12 (#25).
+
+## v3.1.3 - 2025-03-19
+
+- Bump `laravel/framework` from 11.41.3 to 11.44.2 (#24).
+
+## v3.1.2 - 2025-02-01
+
+- Update libraries (#22).
+
+## v3.1.1 - 2024-12-10
+
+- Bump `league/commonmark` from 2.5.3 to 2.6.0 (#20).
+
+## v3.1.0 - 2024-11-28
+
+- Allow sending discounts (#19).
+
+## v3.0.1 - 2024-11-12
+
+- Update libraries (#18).
+
+## v3.0.0 - 2024-04-07
+
+- Support Laravel 11 (#15).
+
+## v2.0.1 - 2023-04-26
+
+- Bump `guzzlehttp/psr7` from 2.4.4 to 2.5.0 (#14).
+
+## v2.0.0 - 2023-03-17
+
+- Support Laravel 10 (#13).
+
+## v1.3.2 - 2022-06-21
+
+- Bump `guzzlehttp/guzzle` from 7.4.4 to 7.4.5 (#12).
+
+## v1.3.1 - 2022-06-10
+
+- Security: bump `guzzlehttp/guzzle` from 7.4.2 to 7.4.4.
+
+## v1.3.0 - 2022-04-11
+
+- Support for Laravel 9.
+
+## v1.2.2 - 2022-03-30
+
+- Security: bump `guzzlehttp/psr7` (#10).
+
+## v1.2.1 - 2021-04-30
+
+- Update to Laravel framework v8.40.0 with security fixes.
+
+## v1.2.0 - 2021-01-23
+
+- Support for decimal numbers in the amount.
+
+## v1.1.1 - 2021-01-19
+
+- Upgrade libraries.
+
+## v1.1.0 - 2020-11-27
+
+- Support for PHP 8.
+
+## v1.0.0 - 2020-10-11
+
+- Minimal working version.
+
+## v0.0.1 - 2020-09-14
+
+- Initial version.
+
+[Unreleased]: https://github.com/puntodev/paypal/compare/v5...HEAD

--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ composer test-coverage   # generates HTML coverage report
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
+## Releasing
+
+Releases are cut from GitHub and the changelog is kept in sync automatically:
+
+1. Merge the pull requests you want to ship into `master`. Label them so the notes
+   group nicely (`security`, `enhancement`, `bug`, `dependencies`, `documentation`);
+   grouping is configured in [`.github/release.yml`](.github/release.yml).
+2. On GitHub, go to **Releases → Draft a new release**, create a `vX.Y.Z` tag
+   following [SemVer](https://semver.org/), and click **Generate release notes**.
+3. **Publish** the release. Packagist picks up the new tag, and the
+   [`update-changelog.yml`](.github/workflows/update-changelog.yml) workflow writes
+   the release notes into `CHANGELOG.md` and commits them back to `master`.
+
+The `Unreleased` section in the changelog is just an anchor — release notes flow
+from the published GitHub release, so there is no changelog to edit by hand.
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.


### PR DESCRIPTION
## Summary

Mirrors the release automation from `bookables`: GitHub Releases drive everything, and the changelog stays in sync automatically.

### What's included
- **`.github/release.yml`** — configures GitHub's *Generate release notes* button, grouping PRs by label (🛡️ Security, 🚀 Features, 🐛 Bug Fixes, 🧰 Maintenance & Dependencies, 📚 Documentation, catch-all). Excludes `ignore-for-release` and dependabot.
- **`.github/workflows/update-changelog.yml`** — on a published (non-prerelease) GitHub Release, writes the release notes into `CHANGELOG.md` and commits them back to `master` using the org-level `RELEASE_TOKEN` admin PAT.
- **`CHANGELOG.md`** — rewritten in [Keep a Changelog](https://keepachangelog.com/) format with an `Unreleased` anchor, backfilling the **full release history** (v0.0.1 → v5).
- **README** — new *Releasing* section documenting the flow.

### Repo configuration (applied out-of-band, matching the other puntodev repos)
- **`master` branch protection** enabled: required status check `build` (strict), linear history, no force-push/deletion, **`enforce_admins: false`** so the PAT can push the changelog commit.
- **Labels** created: `security`, `fix`, `chore`, `maintenance`, `ignore-for-release` (others already existed).
- **`RELEASE_TOKEN`** org secret already grants access to this repo — no new secret needed.

### Release flow (after merge)
1. Merge labeled PRs into `master`.
2. Releases → Draft a new release → create `vX.Y.Z` tag → Generate release notes.
3. Publish → Packagist picks up the tag and the changelog is committed back automatically.

## Test plan
- [x] `vendor/bin/pint --test` passes
- [ ] On the next published release, confirm the changelog commit lands on `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)